### PR TITLE
Fix default azimuth spacing variable name

### DIFF
--- a/src/SWOTRiver/SWOTL2.py
+++ b/src/SWOTRiver/SWOTL2.py
@@ -52,7 +52,7 @@ class SWOTL2:
     +y_0=False Northing, set to 0
     """
 
-    azimuth_spacing_default = 5.3 # default azimuth spacing
+    default_azimuth_spacing = 3.125 # default azimuth spacing
 
     def __init__(self, swotL2_file,bounding_box=None, class_list=[1],
                  lat_kwd='no_layover_latitude', lon_kwd='no_layover_longitude',


### PR DESCRIPTION
Also change default value to 3.125 because that's the value in simulations