### PR TITLE
Update Estimate.py to newpixc format 

### DIFF
--- a/src/SWOTRiver/Estimate.py
+++ b/src/SWOTRiver/Estimate.py
@@ -171,11 +171,12 @@ class L2PixcToRiverTile(object):
             return
 
         cnes_sensor = geoloc_river.Sensor.from_pixc(self.pixc_file)
-
+        pixel_cloud = geoloc_river.PixelCloud.from_file(self.pixc_file)
+        pixvec = geoloc_river.PixcvecRiver(self.index_file, pixel_cloud)
         # compute improved geolocation
         lat_corr, lon_corr, height_corr = geoloc_river.geoloc_river(
-            geoloc_river.PixelCloud.from_file(self.pixc_file),
-            geoloc_river.PixcvecRiver(self.index_file),
+            pixel_cloud,
+            pixvec,
             cnes_sensor,
             geoloc_river.RiverTile.from_node_outputs(self.node_outputs),
             fit_heights_per_reach=True, interpolate_pixc_between_nodes=True,

--- a/src/SWOTRiver/products/rivertile.py
+++ b/src/SWOTRiver/products/rivertile.py
@@ -634,6 +634,17 @@ class RiverTileNodes(Product, ShapeWriterMixIn):
         """Adds more datasets from pixc_file file using index_file"""
         pixc_vec = L2PIXCVector.from_ncfile(index_file)
 
+        #~ pixc2rivertile_map = {
+            #~ '/pixel_cloud/solid_earth_tide': 'earth_tide',
+            #~ '/pixel_cloud/pole_tide': 'pole_tide',
+            #~ '/pixel_cloud/loading_tide_sol1': 'load_tide',
+            #~ '/pixel_cloud/model_dry_tropo_cor': 'dry_trop_c',
+            #~ '/pixel_cloud/model_wet_tropo_cor': 'wet_trop_c',
+            #~ '/pixel_cloud/model_iono_ka_cor': 'iono_c',
+            #~ '/pixel_cloud/xover_height_cor': 'xovr_cal_c',
+            #~ '/tvp/time': 'time',
+            #~ '/tvp/time_tai': 'time_tai'}
+            
         pixc2rivertile_map = {
             '/pixel_cloud/solid_earth_tide': 'earth_tide',
             '/pixel_cloud/pole_tide': 'pole_tide',
@@ -641,10 +652,8 @@ class RiverTileNodes(Product, ShapeWriterMixIn):
             '/pixel_cloud/model_dry_tropo_cor': 'dry_trop_c',
             '/pixel_cloud/model_wet_tropo_cor': 'wet_trop_c',
             '/pixel_cloud/model_iono_ka_cor': 'iono_c',
-            '/pixel_cloud/xover_height_cor': 'xovr_cal_c',
-            '/tvp/time': 'time',
-            '/tvp/time_tai': 'time_tai'}
-
+            '/pixel_cloud/xover_height_cor': 'xovr_cal_c'}
+            
         pixc_data = {}
         with netCDF4.Dataset(pixc_file, 'r') as ifp:
             for key in pixc2rivertile_map:


### PR DESCRIPTION
2 points : 
- a little update in Estimate.py to handle the fact the nr_lines and nr_pixels are not known inside pixvec
- a "problem" in SWOTRiver/products/rivertile.py (/tvp/time and /tvp/time_tai are not correctly extracted from pixel cloud). And then this "subdata = pixc_data[inkey][pixc_vec.azimuth_index]" can't be done.

If you can look at these points Alex
--
Damien

PS : I ask to Victor to push swotCNES on your gitHUB to get updated improved geoloc (for rivers). On lake it is on-going.