### PR TITLE
close netcdf and remove fake pixel cloud

### DIFF
--- a/src/SWOTRiver/Estimate.py
+++ b/src/SWOTRiver/Estimate.py
@@ -130,6 +130,9 @@ class L2PixcToRiverTile(object):
             smooth=self.config['smooth'],
             alpha=self.config['alpha'],
             max_iter=self.config['max_iter'])
+            
+        # Close netcdf now that we're done with it
+        river_estimator.nc.close()
 
         self.node_outputs, self.reach_outputs = None, None
         if len(self.reach_collection) > 0:

--- a/src/bin/swot_pixc2rivertile.py
+++ b/src/bin/swot_pixc2rivertile.py
@@ -122,6 +122,8 @@ def main():
             os.path.join(args.shpbasedir, 'nodes.shp'))
         l2pixc_to_rivertile.rivertile_product.reaches.write_shapes(
             os.path.join(args.shpbasedir, 'reaches.shp'))
+    if args.gdem_file is not None:
+        os.remove('fake_pixel_cloud.nc')
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Doing batch runs of `swot_pixc2rivertile` and underlying functions requires removing the fake_pixel_cloud.nc file, which cannot be done without first closing the `river_estimator.nc` object in SWOTRiver/Estimate.py. Maybe we want to handle the fake_pixel_cloud differently (give an option to keep it?) but there are probably other reasons to close the netcdf. 