### PR TITLE
fix non-composite uncertainty agg methods

### DIFF
--- a/src/SWOTWater/aggregate.py
+++ b/src/SWOTWater/aggregate.py
@@ -410,9 +410,9 @@ def area_uncert(
                                 + var_area_composite_bar
                                 + var_pix_area_composite_bar
                                 + B_term_composite)
-    std_out = std_composite
+        std_out = std_composite
     if method == 'simple':
-        std_out = std_wd
+        std_out = std_dw
     if method == 'water_fraction':
         std_out = std_alpha
     return std_out


### PR DESCRIPTION
Couple of very small bugs preventing "simple" and "water fraction" methods of area uncertainty from working.